### PR TITLE
Add Upstart support for Ubuntu 14.04

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,8 +105,20 @@
     owner: root
     group: root
     mode: 0644
+  when: ansible_distribution != 'Ubuntu' or ansible_distribution_version != '14.04'
   tags:
     - service
+
+- name: Copy the Upstart service file
+  template:
+    src: zeppelin.upstart.conf.j2
+    dest: /etc/init/zeppelin.conf
+    owner: root
+    group: root
+    mode: 0644
+  tags:
+    - service
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '14.04'
 
 - name: Ensure Zeppelin is started and enabled on boot
   service:

--- a/templates/zeppelin.upstart.conf.j2
+++ b/templates/zeppelin.upstart.conf.j2
@@ -1,0 +1,10 @@
+description "zeppelin"
+
+start on (local-filesystems and net-device-up IFACE!=lo)
+stop on shutdown
+
+respawn
+respawn limit 7 5
+
+chdir /opt/zeppelin
+exec bin/zeppelin-daemon.sh upstart


### PR DESCRIPTION
Ubuntu 14.04 is still missing Java 8 though. It is necessary to manually
add a repository that provides it before running this role.
