### PR TITLE
Install headless versions of JRE packages

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,5 @@
 ---
 zeppelin_packages:
-  - openjdk-8-jre
+  - openjdk-8-jre-headless
   - sudo
 java_home: /usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,5 +1,5 @@
 ---
 zeppelin_packages:
-  - java-1.8.0-openjdk
+  - java-1.8.0-openjdk-headless
   - sudo
 java_home: /usr/lib/jvm/jre/


### PR DESCRIPTION
Zeppelin has no need for the complete JRE. The headless versions save some unnecessary dependencies.
