### PR TITLE
Update Zeppelin download URL

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 zeppelin_version: 0.6.1
-zeppelin_download_url: http://www-us.apache.org/dist/zeppelin/zeppelin-{{ zeppelin_version }}/zeppelin-{{ zeppelin_version }}-bin-all.tgz
+zeppelin_download_url: http://archive.apache.org/dist/zeppelin/zeppelin-{{ zeppelin_version }}/zeppelin-{{ zeppelin_version }}-bin-all.tgz
 zeppelin_service_username: zeppelin
 zeppelin_service_group: zeppelin
 zeppelin_working_directory: /tmp/zeppelin_working_directory


### PR DESCRIPTION
The previous URLs seem to have been taken down. Now all links point to
archive.apache.org.