### PR TITLE
Update LDAP/AD classes & don't quote wrap their values

### DIFF
--- a/templates/shiro.ini.j2
+++ b/templates/shiro.ini.j2
@@ -22,16 +22,16 @@
 
 [main]
 {% if zeppelin_auth_active_directory_enabled %}
-activeDirectoryRealm = org.apache.zeppelin.server.ActiveDirectoryGroupRealm
+activeDirectoryRealm = org.apache.zeppelin.realm.ActiveDirectoryGroupRealm
 {% for option, value in zeppelin_auth_active_directory_options | default({}) | dictsort %}
-activeDirectoryRealm.{{ option }} = "{{ value }}"
+activeDirectoryRealm.{{ option }} = {{ value }}
 {% endfor %}
 {% endif %}
 
 {% if zeppelin_auth_ldap_enabled %}
-ldapRealm = org.apache.zeppelin.server.LdapGroupRealm
+ldapRealm = org.apache.zeppelin.realm.LdapGroupRealm
 {% for option, value in zeppelin_auth_ldap_options | default({}) | dictsort %}
-ldapRealm.{{ option }} = "{{ value }}"
+ldapRealm.{{ option }} = {{ value }}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
Hi Kevin,

Firstly, thanks for the role, it's awesome!! I found that when configuring Active Directory, the class name had changed as per this PR, and that quoting the values when they are entered in to the template causes the following exception to be thrown when configuring AD:

```
Caused by: java.lang.NumberFormatException: For input string: "389"
```

- I wonder - should we perhaps change line #25 in `shiro.ini.j2` from `activeDirectoryRealm = org.apache.zeppelin.realm.ActiveDirectoryGroupRealm` to something like this (and set some defaults in `defaults/main.yml`:

```
activeDirectoryRealm = {{ zeppelin_ad_class }}
ldapRealm = {{ zeppelin_ldap_class }}
```

This is instead of the proposed changes in my PR.

I sent you a ping in Gitter if you want to come and blab with me about - I'm around :)
Thanks again!