### PR TITLE
Update zeppelin version to 0.10.1, update handle urls, support Kerberos auth

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -110,3 +110,7 @@ zeppelin_auth_ldap_enabled: false
 zeppelin_auth_ldap_options: {}
 zeppelin_user_caching_enabled: false
 zeppelin_global_session_timeout: 86400000
+
+zeppelin_server_kerberos_enabled: false
+zeppelin_server_kerberos_keytab: /etc/security/keytabs/zeppelin.server.kerberos.keytab
+zeppelin_server_kerberos_principal: change me

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-zeppelin_version: 0.9.0
+zeppelin_version: 0.10.1
 zeppelin_download_url: http://archive.apache.org/dist/zeppelin/zeppelin-{{ zeppelin_version }}/zeppelin-{{ zeppelin_version }}-bin-all.tgz
 zeppelin_service_username: zeppelin
 zeppelin_service_group: zeppelin
@@ -87,8 +87,15 @@ zeppelin_pyspark_python:
 zeppelin_pythonpath:
 
 # Config options for shiro.ini
-zeppelin_users: [{name: 'admin', password: 'password', roles: ['admin']}]
+zeppelin_users: [
+  {name: 'admin', password: 'password', roles: ['admin']},
+  {name: 'user', password: 'pass', roles: ['user']}
+]
 zeppelin_roles: [{name: 'admin', value: '*'}]
+zeppelin_urls: [
+  {roles: ['admin'], url: '/api/interpreter/**', value: 'authc'},
+  {roles: ['admin'], url: '/api/configurations/**', value: 'authc'}
+]
 zeppelin_auth_active_directory_enabled: false
 zeppelin_auth_active_directory_options: {}
 zeppelin_auth_ldap_enabled: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -87,15 +87,23 @@ zeppelin_pyspark_python:
 zeppelin_pythonpath:
 
 # Config options for shiro.ini
-zeppelin_users: [
-  {name: 'admin', password: 'password', roles: ['admin']},
-  {name: 'user', password: 'pass', roles: ['user']}
-]
-zeppelin_roles: [{name: 'admin', value: '*'}]
-zeppelin_urls: [
-  {roles: ['admin'], url: '/api/interpreter/**', value: 'authc'},
-  {roles: ['admin'], url: '/api/configurations/**', value: 'authc'}
-]
+zeppelin_users:
+  - name: admin
+    password: password
+    roles: [admin]
+  - name: user
+    password: pass
+    roles: [user]
+zeppelin_roles:
+  - name: admin
+    value: "*"
+zeppelin_urls:
+  - roles: [admin]
+    url: /api/interpreter/**
+    value: authc
+  - roles: [admin]
+    url: /api/configurations/**
+    value: authc
 zeppelin_auth_active_directory_enabled: false
 zeppelin_auth_active_directory_options: {}
 zeppelin_auth_ldap_enabled: false

--- a/templates/shiro.ini.j2
+++ b/templates/shiro.ini.j2
@@ -59,8 +59,3 @@ shiro.loginUrl = /api/login
 {% for perms in zeppelin_urls %}
 {{ perms.url }} = {{ perms.value }}, roles[{{ perms.roles | join(', ') }}]
 {% endfor %}
-{% if zeppelin_anonymous_allowed %}
-/** = anon
-{% else %}
-/** = authc
-{% endif %}

--- a/templates/shiro.ini.j2
+++ b/templates/shiro.ini.j2
@@ -56,6 +56,9 @@ shiro.loginUrl = /api/login
 
 [urls]
 /api/version = anon
+{% for perms in zeppelin_urls %}
+{{ perms.url }} = {{ perms.value }}, roles[{{ perms.roles | join(', ') }}]
+{% endfor %}
 {% if zeppelin_anonymous_allowed %}
 /** = anon
 {% else %}

--- a/templates/zeppelin-site.xml.j2
+++ b/templates/zeppelin-site.xml.j2
@@ -267,4 +267,18 @@
   <description>Size in characters of the maximum text message to be received by websocket. Defaults to 1024000</description>
 </property>
 
+{% if zeppelin_server_kerberos_enabled == True %}
+<property>
+  <name>zeppelin.server.kerberos.keytab</name>
+  <value>{{ zeppelin_server_kerberos_keytab }}</value>
+</property>
+{% endif %}
+
+{% if zeppelin_server_kerberos_principal != "change me" %}
+<property>
+  <name>zeppelin.server.kerberos.principal</name>
+  <value>{{ zeppelin_server_kerberos_principal }}</value>
+</property>
+{% endif %}
+
 </configuration>


### PR DESCRIPTION
- Update Zeppelin to the latest version: 0.10.1.
- Handle roles for specific urls (added default vars)
- Support Kerberos authentication
- Reformat default variables.